### PR TITLE
Sets the scale to a constant 1.0f.

### DIFF
--- a/src/main/java/net/vektah/codeglance/GlancePanel.java
+++ b/src/main/java/net/vektah/codeglance/GlancePanel.java
@@ -207,10 +207,12 @@ public class GlancePanel extends JPanel implements VisibleAreaListener {
 
 	private float getHidpiScale() {
 		// Work around for apple going full retard with half pixel pixels.
-		Float scale = (Float)Toolkit.getDefaultToolkit().getDesktopProperty("apple.awt.contentScaleFactor");
-		if (scale == null) {
-			scale = 1.0f;
-		}
+		// Removed temporarily as a fix for bugged scaling on OS X
+		//Float scale = (Float)Toolkit.getDefaultToolkit().getDesktopProperty("apple.awt.contentScaleFactor");
+		//if (scale == null) {
+		//	scale = 1.0f;
+		//}
+		float scale = 1.0f;
 
 		return scale;
 	}


### PR DESCRIPTION
Because Mac OS X _seems_ to resolve DPI issues itself, we don't need to get the scale factor. The code has simply been commented out for now until this is verified to not suffer from "works on my machine" syndrome.

In my tests, a scale of 1.0f works on both a 15-inch retina MacBook Pro display as well as an attached Thunderbolt display.

**Please note:** If you run into issues with this on Mac, please file them at [my fork](https://github.com/dambrisco/CodeGlance/issues) as Vektah is unable to debug issues related to OS X.
