### PR TITLE
Blocky mode

### DIFF
--- a/src/main/java/net/vektah/codeglance/config/Config.kt
+++ b/src/main/java/net/vektah/codeglance/config/Config.kt
@@ -26,12 +26,13 @@
 package net.vektah.codeglance.config
 
 class Config {
-    public var pixelsPerLine: Int = 3
-    public var minLineCount: Int = 1
-    public var maxFileSize: Int = 1024000
-    public var disabled: Boolean = false
-    public var jumpOnMouseDown: Boolean = true
-    public var percentageBasedClick: Boolean = false
-    public var width: Int = 110
-    public var viewportColor: String = "A0A0A0"
+    var pixelsPerLine: Int = 3
+    var minLineCount: Int = 1
+    var maxFileSize: Int = 1024000
+    var disabled: Boolean = false
+    var jumpOnMouseDown: Boolean = true
+    var percentageBasedClick: Boolean = false
+    var width: Int = 110
+    var viewportColor: String = "A0A0A0"
+    var clean: Boolean = true
 }

--- a/src/main/java/net/vektah/codeglance/config/ConfigEntry.kt
+++ b/src/main/java/net/vektah/codeglance/config/ConfigEntry.kt
@@ -51,11 +51,15 @@ class ConfigEntry : Configurable {
         return form!!.root
     }
 
-    override fun isModified(): Boolean {
-        if (form == null) return false
-
-        return config.pixelsPerLine != form!!.pixelsPerLine || config.disabled != form!!.isDisabled || config.jumpOnMouseDown != form!!.jumpOnMouseDown() || config.percentageBasedClick != form!!.percentageBasedClick() || config.width != form!!.width || config.viewportColor !== form!!.viewportColor || config.minLineCount != form!!.minLinesCount
-    }
+    override fun isModified() = form != null &&
+            (config.pixelsPerLine != form!!.pixelsPerLine
+            || config.disabled != form!!.isDisabled
+            || config.jumpOnMouseDown != form!!.jumpOnMouseDown()
+            || config.percentageBasedClick != form!!.percentageBasedClick()
+            || config.width != form!!.width
+            || config.viewportColor !== form!!.viewportColor
+            || config.minLineCount != form!!.minLinesCount
+            || config.clean != form!!.cleanStyle)
 
     @Throws(ConfigurationException::class)
     override fun apply() {
@@ -74,6 +78,7 @@ class ConfigEntry : Configurable {
         }
 
         config.minLineCount = form!!.minLinesCount
+        config.clean = form!!.cleanStyle
         configService.notifyChange()
     }
 
@@ -87,6 +92,7 @@ class ConfigEntry : Configurable {
         form!!.viewportColor = config.viewportColor
         form!!.width = config.width
         form!!.minLinesCount = config.minLineCount
+        form!!.cleanStyle = config.clean
     }
 
     override fun disposeUIResources() {

--- a/src/main/java/net/vektah/codeglance/config/ConfigForm.form
+++ b/src/main/java/net/vektah/codeglance/config/ConfigForm.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="net.vektah.codeglance.config.ConfigForm">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="8" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="9" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="458" height="499"/>
+      <xy x="20" y="20" width="458" height="509"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -134,7 +134,7 @@
       </component>
       <vspacer id="d0587">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="cc1c9" class="javax.swing.JTextField" binding="minLinesCount">
@@ -145,6 +145,25 @@
         </constraints>
         <properties>
           <text value=""/>
+        </properties>
+      </component>
+      <component id="d9d56" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Render Style"/>
+        </properties>
+      </component>
+      <component id="2c8ac" class="javax.swing.JComboBox" binding="renderStyle">
+        <constraints>
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <model>
+            <item value="Clean"/>
+            <item value="Accurate"/>
+          </model>
         </properties>
       </component>
     </children>

--- a/src/main/java/net/vektah/codeglance/config/ConfigForm.java
+++ b/src/main/java/net/vektah/codeglance/config/ConfigForm.java
@@ -42,11 +42,13 @@ public class ConfigForm {
 	private JTextField width;
 	private JTextField viewportColor;
 	private JTextField minLinesCount;
+	private JComboBox renderStyle;
 
 	public ConfigForm() {
 		pixelsPerLine.setModel(new DefaultComboBoxModel(new Integer[]{1, 2, 3, 4}));
 		jumpToPosition.setModel(new DefaultComboBoxModel(new String[]{"Mouse Down", "Mouse Up"}));
 		clickStyle.setModel(new DefaultComboBoxModel(new String[]{"Scrollbar (old sublime)", "To Text (new sublime)"}));
+		renderStyle.setModel(new DefaultComboBoxModel(new String[]{"Clean", "Accurate"}));
 	}
 
 	public JPanel getRoot() {
@@ -91,6 +93,14 @@ public class ConfigForm {
 
 	public void setViewportColor(String color) {
 		viewportColor.setText(color);
+	}
+
+	public boolean getCleanStyle() {
+		return renderStyle.getSelectedIndex() == 0;
+	}
+
+	public void setCleanStyle(boolean isClean) {
+		renderStyle.setSelectedIndex(isClean ? 0 : 1);
 	}
 
 	public int getWidth() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin url="https://github.com/Vektah/CodeGlance">
 	<id>net.vektah.codeglance</id>
 	<name>CodeGlance</name>
-	<version>1.4.5</version>
+	<version>1.4.6</version>
 	<vendor email="adam@vektah.net" url="https://github.com/Vektah/CodeGlance">Vektah</vendor>
 
 	<description>


### PR DESCRIPTION
Implements https://github.com/Vektah/CodeGlance/issues/160

Adds a new default  "clean" renderer that looks like this:
![image](https://cloud.githubusercontent.com/assets/2247982/23823014/ea854464-06ac-11e7-9351-715aa251cad9.png)

the old "accurate" renderer looks like this:
![image](https://cloud.githubusercontent.com/assets/2247982/23823023/0727f40e-06ad-11e7-8545-451021d67c31.png)

