### PR TITLE
Fix Int overflow when calculating viewport area position in large files

### DIFF
--- a/src/main/java/net/vektah/codeglance/GlancePanel.kt
+++ b/src/main/java/net/vektah/codeglance/GlancePanel.kt
@@ -268,10 +268,9 @@ class GlancePanel(private val project: Project, fileEditor: FileEditor, private 
         }
 
         val visibleArea = editor.scrollingModel.visibleArea
-        val start = scrollstate.documentHeight * visibleArea.y / editor.contentComponent.height
-        val end = scrollstate.documentHeight * visibleArea.height / editor.contentComponent.height
+        val factor = scrollstate.documentHeight.toDouble() / editor.contentComponent.height
 
-        scrollstate.setViewportArea(start, end)
+        scrollstate.setViewportArea((factor * visibleArea.y).toInt(), (factor * visibleArea.height).toInt())
         scrollstate.setVisibleHeight(height)
 
         if (currentFoldCount != lastFoldCount) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
 	<change-notes><![CDATA[
 	    <h3>1.5.3</h3>
 		<ul>
+			<li>Bugfix: Viewport position now calculates correctly for large files</li>
 		    <li>Bugfix: Render style and alignment now save correctly</li>
 		    <li>Bugfix: Queue full</li>
 		</ul>


### PR DESCRIPTION
I had some scrolling problems with large files (more than 6000 lines) in my projects. I think it also relates to the existing issue [#178](https://github.com/vektah/CodeGlance/issues/178).