### PR TITLE
Fix slow isFolded checks in Folds

### DIFF
--- a/src/main/java/net/vektah/codeglance/render/Folds.kt
+++ b/src/main/java/net/vektah/codeglance/render/Folds.kt
@@ -29,27 +29,19 @@ import com.intellij.openapi.editor.FoldRegion
 
 // Is a copy of Array<FoldRegion> that only contains folded folds and can be passed safely to another thread
 class Folds{
-    private val starts: ArrayList<Int>
-    private val ends: ArrayList<Int>
+    private val foldsSet: HashSet<Int> = hashSetOf()
 
     constructor(allFolds: Array<FoldRegion>) {
-        starts = ArrayList()
-        ends = ArrayList()
         allFolds
             .filterNot { it.isExpanded }
             .forEach { foldRegion ->
-                if (ends.size == 0 || ends.last() < foldRegion.startOffset) {
-                    starts.add(foldRegion.startOffset)
-                    ends.add(foldRegion.endOffset)
-                }
+                for (index in foldRegion.startOffset until foldRegion.endOffset)
+                    foldsSet.add(index)
             }
     }
 
     // Used by tests that want an empty fold set
-    constructor() {
-        starts = ArrayList()
-        ends = ArrayList()
-    }
+    constructor()
 
     /**
      * Checks if a given position is within a folded region
@@ -58,7 +50,6 @@ class Folds{
      * @return true if the given position is folded.
      */
     fun isFolded(position: Int): Boolean {
-        val index = starts.binarySearch(position)
-        return (0 <= index || (index != -1 && position < ends[-(index+1)-1])) // see binarySearch() docs
+        return foldsSet.contains(position)
     }
 }

--- a/src/main/java/net/vektah/codeglance/render/Folds.kt
+++ b/src/main/java/net/vektah/codeglance/render/Folds.kt
@@ -29,27 +29,26 @@ import com.intellij.openapi.editor.FoldRegion
 
 // Is a copy of Array<FoldRegion> that only contains folded folds and can be passed safely to another thread
 class Folds{
-    private val starts: IntArray
-    private val ends: IntArray
+    private val starts: ArrayList<Int>
+    private val ends: ArrayList<Int>
 
     constructor(allFolds: Array<FoldRegion>) {
-        val numFolds = allFolds.count { !it.isExpanded }
-
-        starts = IntArray(numFolds)
-        ends = IntArray(numFolds)
-
+        starts = ArrayList()
+        ends = ArrayList()
         allFolds
             .filterNot { it.isExpanded }
-            .forEachIndexed { index, foldRegion ->
-                starts[index] = foldRegion.startOffset
-                ends[index] = foldRegion.endOffset
+            .forEach { foldRegion ->
+                if (ends.size == 0 || ends.last() < foldRegion.startOffset) {
+                    starts.add(foldRegion.startOffset)
+                    ends.add(foldRegion.endOffset)
+                }
             }
     }
 
     // Used by tests that want an empty fold set
     constructor() {
-        starts = intArrayOf()
-        ends = intArrayOf()
+        starts = ArrayList()
+        ends = ArrayList()
     }
 
     /**

--- a/src/test/java/net/vektah/codeglance/render/FoldsTest.kt
+++ b/src/test/java/net/vektah/codeglance/render/FoldsTest.kt
@@ -71,6 +71,7 @@ class FoldsTest {
         assertTrue(folds.isFolded(13))
         assertTrue(folds.isFolded(14))
         assertTrue(folds.isFolded(18))
+        assertFalse(folds.isFolded(20))
         assertFalse(folds.isFolded(25))
     }
 }

--- a/src/test/java/net/vektah/codeglance/render/FoldsTest.kt
+++ b/src/test/java/net/vektah/codeglance/render/FoldsTest.kt
@@ -57,4 +57,20 @@ class FoldsTest {
         assertFalse(folds.isFolded(15))
         assertFalse(folds.isFolded(25))
     }
+
+    @Test fun testNestedFoldedRegions() {
+        val folds = Folds(arrayOf(
+            FakeFold(10, 20, true),
+            FakeFold(12, 16, true),
+            FakeFold(14, 15, true),
+            FakeFold(18, 19, true)
+        ))
+
+        assertFalse(folds.isFolded(0))
+        assertTrue(folds.isFolded(11))
+        assertTrue(folds.isFolded(13))
+        assertTrue(folds.isFolded(14))
+        assertTrue(folds.isFolded(18))
+        assertFalse(folds.isFolded(25))
+    }
 }


### PR DESCRIPTION
Fix #218 
What actually slowing down minimap refresh was linear search inside `Folds#isFolded()` method (that invoked inside nested loops at `Minimap#update()`). 
![image](https://user-images.githubusercontent.com/14268320/45791075-07456d80-bc56-11e8-91e6-888c37c21c29.png)
