### PR TITLE
Fixed Typo or Two and Added Hot Key Combo to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ Running from source in Intellj
 6. In order to run tests you will need to find mockito and testng jars. I usually do this with gradle.
 7. In module settings set the path to META-INF to src/main/resources
 8. Hit Run.
+
+
+Show/Hide or Enable/Disable Minimap
+===================
+* **Ctrl-Shift-G** to toggle minimap.
+* Settings > Other Settings > CodeGlance

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ CodeGlance [![CircleCI](https://circleci.com/gh/Vektah/CodeGlance/tree/master.sv
 Plugin Repository: http://plugins.jetbrains.com/plugin/7275  
 Latest build: https://github.com/Vektah/CodeGlance/releases
 
-Intelij plugin that displays a zoomed out overview or minimap similar to the one found in Sublime into the editor pane. The minimap allows for quick scrolling letting you jump straight to sections of code.
+InteliJ plugin that displays a zoomed out overview or minimap similar to the one found in Sublime into the editor pane. The minimap allows for quick scrolling letting you jump straight to sections of code.
 
  - Works with both light and dark themes using your customized colors for syntax highlighting.
  - Worker thread for rendering
- - Color rendering using intelij's tokenizer
+ - Color rendering using InteliJ's tokenizer
  - Scrollable!
  - Embedded into editor window
  - Complete replacement for Code Outline that supports new Intellij builds.
@@ -16,7 +16,7 @@ Intelij plugin that displays a zoomed out overview or minimap similar to the one
 ![Dracula](https://raw.github.com/Vektah/CodeGlance/master/pub/example.png)
 
 
-Building using gradle
+Building using Gradle
 ====================
 ```
 git clone https://github.com/Vektah/CodeGlance
@@ -34,14 +34,14 @@ cd CodeGlance
 The result will be saved as build/distributions/CodeGlance-{version}.zip
 
 
-Running from source in Intellj
+Running from source in IntellJ
 ===================
 1. Make sure you have the Plugin DevKit installed.
 2. Checkout sources from github
 3. Create a new Intellij Platform plugin project
 4. Select source directory, chose a plugin sdk (create one that points to your intellij install).
 5. Mark src/main/java as source root, and src/test/java as test root.
-6. In order to run tests you will need to find mockito and testng jars. I usually do this with gradle.
+6. In order to run tests you will need to find mockito and testing jars. I usually do this with Gradle.
 7. In module settings set the path to META-INF to src/main/resources
 8. Hit Run.
 


### PR DESCRIPTION
Just added the hotkey to the readme and fixed a couple of typos... I dunno why, great plugin, seemed to be a shame that the plugin page and the readme missed a couple of details (or I did and it is in huge letters somewhere where I missed it!)